### PR TITLE
A little translation mistake in Turkish Language.

### DIFF
--- a/lib/src/languages/turkish.dart
+++ b/lib/src/languages/turkish.dart
@@ -16,7 +16,7 @@ class Turkish implements Language {
   @override
   String suffixFromNow() => shortForm ? '' : 'şu andan itibaren';
   @override
-  String lessThanOneMinute(int seconds) => 'şimdi';
+  String lessThanOneMinute(int seconds) => shortForm ? 'şimdi' : 'birkaç saniye';
   @override
   String aboutAMinute(int minutes) => shortForm ? '1 dk' : 'bir dakika';
   @override


### PR DESCRIPTION
"Şimdi önce" is a wrong term. It should be "birkaç saniye önce" for long version and "şimdi" for short.