### PR TITLE
Fixup formatting in certain cases

### DIFF
--- a/lib/src/time_ago_provider.dart
+++ b/lib/src/time_ago_provider.dart
@@ -16,7 +16,7 @@ import 'languages/turkish.dart';
 /// - If [enableFromNow] is passed, format will use the From prefix, ie. a date
 ///   9 minutes from now in 'en' locale will display as "9 minutes from now"
 String format(DateTime date,
-    {String locale = 'en', DateTime clock, bool enableFromNow = false}) {
+    {String locale = 'en', DateTime? clock, bool enableFromNow = false}) {
   final language = _languages[locale] ?? English();
   clock ??= DateTime.now();
 
@@ -69,7 +69,7 @@ String format(DateTime date,
 }
 
 String formatFull(DateTime date,
-    {String locale = 'en', DateTime clock, bool enableFromNow = false}) {
+    {String locale = 'en', DateTime? clock, bool enableFromNow = false}) {
   final language = _languages[locale] ?? English();
   clock ??= DateTime.now();
   final duration = clock.difference(date);

--- a/lib/src/time_ago_provider.dart
+++ b/lib/src/time_ago_provider.dart
@@ -16,7 +16,7 @@ import 'languages/turkish.dart';
 /// - If [enableFromNow] is passed, format will use the From prefix, ie. a date
 ///   9 minutes from now in 'en' locale will display as "9 minutes from now"
 String format(DateTime date,
-    {String locale = 'en', DateTime? clock, bool enableFromNow = false}) {
+    {String locale = 'en', DateTime clock, bool enableFromNow = false}) {
   final language = _languages[locale] ?? English();
   clock ??= DateTime.now();
 
@@ -69,7 +69,7 @@ String format(DateTime date,
 }
 
 String formatFull(DateTime date,
-    {String locale = 'en', DateTime? clock, bool enableFromNow = false}) {
+    {String locale = 'en', DateTime clock, bool enableFromNow = false}) {
   final language = _languages[locale] ?? English();
   clock ??= DateTime.now();
   final duration = clock.difference(date);

--- a/lib/src/time_ago_provider.dart
+++ b/lib/src/time_ago_provider.dart
@@ -101,7 +101,7 @@ String formatFull(DateTime date,
   }
 
   if (days > 0) {
-    if (months > 0) {
+    if (months > 0 || years > 0) {
       buffer.write(', ');
     }
 
@@ -109,7 +109,7 @@ String formatFull(DateTime date,
   }
 
   if (hours > 0) {
-    if (days > 0) {
+    if (days > 0 || months > 0 || years > 0) {
       buffer.write(', ');
     }
 
@@ -117,7 +117,7 @@ String formatFull(DateTime date,
   }
 
   if (minutes > 0) {
-    if (hours > 0) {
+    if (hours > 0 || days > 0 || months > 0 || years > 0) {
       buffer.write(', ');
     }
 
@@ -125,7 +125,7 @@ String formatFull(DateTime date,
   }
 
   if (seconds > 0) {
-    if (minutes > 0) {
+    if (minutes > 0 || hours > 0 || days > 0 || months > 0 || years > 0) {
       buffer.write(', ');
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: time_ago_provider
 description: library for generating fuzzy timestamp for example ("9 minutes ago")
-version: 3.0.0-dev.1
+version: 3.0.0
 homepage: https://github.com/BaderEddineOuaich/time_ago_provider
 author: Bader Eddine Ouaich <badereddineouaich@gmail.com>
 
 environment:
-  sdk: '>=2.12.0-51.0.dev <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: time_ago_provider
 description: library for generating fuzzy timestamp for example ("9 minutes ago")
-version: 3.0.0
+version: 3.0.0-dev.1
 homepage: https://github.com/BaderEddineOuaich/time_ago_provider
 author: Bader Eddine Ouaich <badereddineouaich@gmail.com>
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-51.0.dev <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
Hi, this PR fixes formatting of my previously merged PR.
In situations if given formating is 6 years and 4 days it will output:
`6 years4 days` which is incorrect. After this PR it displays it correctly `6 years, 4 days`