### PR TITLE
Dart 2.12 support; Bug fix for formatFull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,68 +1,14 @@
-## 0.0.1
+## 4.0.0
+Breaking changes: This version requires Dart SDK 2.12.x
 
-- Initial version.
+- Support for Dart 2.12 with null safety
+- Fixed severe bug with formatFull function
 
-## 0.1.0
+## 3.2.0
+- Added Italian Language by @TommasoAzz
 
-- Stable version.
-
-## 0.1.1
-
-- Code improved.
-
-## 1.0.0
-
-- Method's Parameter (timeStamp) is now required.
-
-## 1.0.1
-
-- Example Edited.
-
-## 1.0.2
-
-- README.md Edited.
-
-## 1.0.3
-
-- README.md Edited 1.
-
-## 2.0.0
-
-- Languages Abstraction
-
-## 2.0.1
-
-- Added Doc Comments 
-
-## 2.0.2
-
-- Added Arabic, French Language Support
-
-## 2.0.3
-## 2.0.4
-
-- Formatted documents
-
-## 2.0.5
-
-- Added Polish Language Support
-
-## 2.1.0
-
-- Added Turkish Language Support
-
-## 2.2.0
-
-- Added Turkish to languages map.
-- Fixed a Bug in Turkish class
-
-## 2.2.1
-
-- A little translation mistake in Turkish Language fix.
-
-## 2.3.1
-
-- Added Portuguese Language
+## 3.1.0
+- Fixup formatting in certain cases by @l7ssha
 
 ## 3.0.0
 
@@ -70,8 +16,72 @@
 - Added Support for Seconds unit
 - Added Support for Detailed format formatFull() e.g: '3 years, 9 months, 9 days, 6 hours, 8 minutes, 3 seconds'
 
-## 3.1.0
-- Fixup formatting in certain cases by @l7ssha
+## 2.3.1
 
-## 3.2.0
-- Added Italian Language by @TommasoAzz
+- Added Portuguese Language
+
+## 2.2.1
+
+- A little translation mistake in Turkish Language fix.
+
+## 2.2.0
+
+- Added Turkish to languages map.
+- Fixed a Bug in Turkish class
+
+## 2.1.0
+
+- Added Turkish Language Support
+
+
+## 2.0.5
+
+- Added Polish Language Support
+
+## 2.0.4
+
+- Formatted documents
+
+## 2.0.3
+
+- Formatted documents
+
+## 2.0.2
+
+- Added Arabic, French Language Support
+
+## 2.0.1
+
+- Added Doc Comments
+
+## 2.0.0
+
+- Languages Abstraction
+
+## 1.0.3
+
+- README.md Edited 1.
+
+## 1.0.2
+
+- README.md Edited.
+
+## 1.0.1
+
+- Example Edited.
+
+## 1.0.0
+
+- Method's Parameter (timeStamp) is now required.
+
+## 0.1.1
+
+- Code improved.
+
+## 0.1.0
+
+- Stable version.
+
+## 0.0.1
+
+- Initial version.

--- a/lib/src/time_ago_provider.dart
+++ b/lib/src/time_ago_provider.dart
@@ -17,7 +17,7 @@ import 'languages/turkish.dart';
 /// - If [enableFromNow] is passed, format will use the From prefix, ie. a date
 ///   9 minutes from now in 'en' locale will display as "9 minutes from now"
 String format(DateTime date,
-    {String locale = 'en', DateTime clock, bool enableFromNow = false}) {
+    {String locale = 'en', DateTime? clock, bool enableFromNow = false}) {
   final language = _languages[locale] ?? English();
   clock ??= DateTime.now();
 
@@ -70,12 +70,11 @@ String format(DateTime date,
 }
 
 String formatFull(DateTime date,
-    {String locale = 'en', DateTime clock, bool enableFromNow = false}) {
+    {String locale = 'en', DateTime? clock, bool enableFromNow = false}) {
   final language = _languages[locale] ?? English();
   clock ??= DateTime.now();
-  final duration = clock.difference(date);
-  final buffer = StringBuffer();
 
+  final duration = clock.difference(date);
   final seconds = duration.inSeconds % 60;
 
   if (duration.inSeconds < 1) {
@@ -89,51 +88,33 @@ String formatFull(DateTime date,
   final months = _months % 12;
   final years = (_months / 12).floor();
 
+  final stringParts = <String>[];
+
   if (years > 0) {
-    buffer.write(language.years(years));
+    stringParts.add(language.years(years));
   }
 
   if (months > 0) {
-    if (years > 0) {
-      buffer.write(', ');
-    }
-
-    buffer.write(language.months(months));
+    stringParts.add(language.months(months));
   }
 
   if (days > 0) {
-    if (months > 0 || years > 0) {
-      buffer.write(', ');
-    }
-
-    buffer.write(language.days(days));
+    stringParts.add(language.days(days));
   }
 
   if (hours > 0) {
-    if (days > 0 || months > 0 || years > 0) {
-      buffer.write(', ');
-    }
-
-    buffer.write(language.hours(hours));
+    stringParts.add(language.hours(hours));
   }
 
   if (minutes > 0) {
-    if (hours > 0 || days > 0 || months > 0 || years > 0) {
-      buffer.write(', ');
-    }
-
-    buffer.write(language.minutes(minutes));
+    stringParts.add(language.minutes(minutes));
   }
 
   if (seconds > 0) {
-    if (minutes > 0 || hours > 0 || days > 0 || months > 0 || years > 0) {
-      buffer.write(', ');
-    }
-
-    buffer.write(language.seconds(seconds));
+    stringParts.add(language.seconds(seconds));
   }
 
-  return buffer.toString();
+  return stringParts.join(', ');
 }
 
 /// Locales/Languages Map, add desired locales by calling

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: time_ago_provider
 description: library for generating fuzzy timestamp for example ("9 minutes ago")
-version: 3.2.0
+version: 4.0.0
 homepage: https://github.com/BaderEddineOuaich/time_ago_provider
 author: Bader Eddine Ouaich <badereddineouaich@gmail.com>
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.0.0
-  test: ^1.0.0
+  pedantic: "^1.11.0"
+  test: "^1.16.8"


### PR DESCRIPTION
Hi this PR adds mainly adds support for dart sdk `2.12`. I've bumped version to `4.0.0` because it's breaks previous versions due requirement of dart `2.12`. Also I fixed major bug in formatFull and I refactored method to more clean and readable code. 

Also due support for sdk 2.12 I've updated dependencies to it's latest versions and fixed changelog beacause it was inverted.